### PR TITLE
Update links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 	* `hautelook_alice:doctrine:fixtures:load`
 	* `hautelook_alice:doctrine:mongodb:fixtures:load`
 	* `hautelook_alice:doctrine:phpcr:fixtures:load`
-* Possibility to [load fixtures by environment](https://github.com/hautelook/AliceBundle/blob/master/src/Resources/doc/advanced-usage.md#environment-specific-fixtures)
-* Possibility to [load fixtures by bundle](https://github.com/hautelook/AliceBundle#basic-usage)
+* Possibility to [load fixtures by environment](https://github.com/theofidry/AliceBundle/blob/master/doc/advanced-usage.md#environment-specific-fixtures)
+* Possibility to [load fixtures by bundle](https://github.com/theofidry/AliceBundle#basic-usage)
 * No longer need to create a data loader to load fixtures
 * Removed [DoctrineFixturesBundle](https://github.com/doctrine/DoctrineFixturesBundle) dependency
 * Now possible to register [Alice Processors][1]

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ The database support is done in [FidryAliceDataFixtures](https://github.com/theo
 project to know which database/ORM is supported.
 
 **Warning: this is the documentation for HautelookAliceBundle 2.0. If you want to check the documentation for 1.x, head
-[this way](https://github.com/hautelook/AliceBundle/tree/1.x).**
+[this way](https://github.com/theofidry/AliceBundle/tree/1.x).**
 
 [![Package version](https://img.shields.io/packagist/v/hautelook/alice-bundle.svg?style=flat-square)](https://packagist.org/packages/hautelook/alice-bundle)
-[![Build Status](https://img.shields.io/travis/hautelook/AliceBundle/master.svg?style=flat-square)](https://travis-ci.org/hautelook/AliceBundle?branch=master)
+[![Build Status](https://img.shields.io/github/workflow/status/theofidry/AliceBundle/CI.svg?style=flat-square)](https://github.com/theofidry/AliceBundle/actions)
 [![SensioLabsInsight](https://img.shields.io/sensiolabs/i/d93a3fc4-3fe8-4be3-aa62-307f53898199.svg?style=flat-square)](https://insight.sensiolabs.com/projects/d93a3fc4-3fe8-4be3-aa62-307f53898199)
 [![Dependency Status](https://www.versioneye.com/user/projects/55d26478265ff6001a000084/badge.svg?style=flat)](https://www.versioneye.com/user/projects/55d26478265ff6001a000084)
 [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/hautelook/AliceBundle.svg?style=flat-square)](https://scrutinizer-ci.com/g/hautelook/AliceBundle/?branch=master)
@@ -284,7 +284,7 @@ class NewsTest extends WebTestCase
 
 This bundle was originaly developped by [Baldur RENSCH](https://github.com/baldurrensch) and [HauteLook](https://github.com/hautelook). It is now maintained by [Théo FIDRY](https://github.com/theofidry).
 
-[Other contributors](https://github.com/hautelook/AliceBundle/graphs/contributors).
+[Other contributors](https://github.com/theofidry/AliceBundle/graphs/contributors).
 
 
 ## License

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -25,15 +25,15 @@
 
 ### Upgrading the data loaders
 
-1. You data loader should now either extend [`Hautelook\AliceBundle\Doctrine\DataFixtures\AbstractLoader`](https://github.com/hautelook/AliceBundle/tree/1.x/src/Doctrine/DataFixtures/AbstractLoader.php) or implement [`Hautelook\AliceBundle\Doctrine\DataFixtures\LoaderInterface`](https://github.com/hautelook/AliceBundle/tree/1.x/src/Doctrine/DataFixtures/LoaderInterface.php).
+1. You data loader should now either extend [`Hautelook\AliceBundle\Doctrine\DataFixtures\AbstractLoader`](https://github.com/theofidry/AliceBundle/tree/1.x/src/Doctrine/DataFixtures/AbstractLoader.php) or implement [`Hautelook\AliceBundle\Doctrine\DataFixtures\LoaderInterface`](https://github.com/theofidry/AliceBundle/tree/1.x/src/Doctrine/DataFixtures/LoaderInterface.php).
 
 2. If you were overriding the `::load()` function of the data loader, you should not need it anymore now:
-  * Custom Faker providers can now be registered, cf [Custom Faker Providers](https://github.com/hautelook/AliceBundle/tree/1.x/src/Resources/doc/faker-providers.md).
-  * Custom Alice processors can now be registered, cf [Custom Processors](https://github.com/hautelook/AliceBundle/tree/1.x/src/Resources/doc/alice-processors.md).
+  * Custom Faker providers can now be registered, cf [Custom Faker Providers](https://github.com/theofidry/AliceBundle/tree/1.x/src/Resources/doc/faker-providers.md).
+  * Custom Alice processors can now be registered, cf [Custom Processors](https://github.com/theofidry/AliceBundle/tree/1.x/src/Resources/doc/alice-processors.md).
 
 3. If you had very long path for some fixtures because you needed to refer to the fixtures of another bundle, you can now use the bundle annotation `@Bundlename`.
 
-4. If you had several data loaders to manage different set of fixtures depending of your environment, now you can [devide your fixtures by environment](https://github.com/hautelook/AliceBundle/tree/1.x/src/Resources/doc/advanced-usage.md#environment-specific-fixtures) instead of having to use and specify a data loader for that.
+4. If you had several data loaders to manage different set of fixtures depending of your environment, now you can [devide your fixtures by environment](https://github.com/theofidry/AliceBundle/tree/1.x/src/Resources/doc/advanced-usage.md#environment-specific-fixtures) instead of having to use and specify a data loader for that.
 
 
 ### Doctrine command
@@ -43,7 +43,7 @@ You should now rely on the bundle command `hautelook_alice:doctrine:fixtures:loa
 
 ### Remove DoctrineFixturesBundle
 
-As explained [here](https://github.com/hautelook/AliceBundle/tree/1.x/src/Resources/doc/doctrine-fixtures-bundle.md), there is no obligation to do so. HautelookAliceBundle is fully compatible with it. However it does not make sense to use the both of them together. It is recommended to
+As explained [here](https://github.com/theofidry/AliceBundle/tree/1.x/src/Resources/doc/doctrine-fixtures-bundle.md), there is no obligation to do so. HautelookAliceBundle is fully compatible with it. However it does not make sense to use the both of them together. It is recommended to
 choose only one.
 
 [Back to the documentation](README.md)


### PR DESCRIPTION
Updates links to use the new fork's URL

Some links are broken due to a missing 1.x branch.  This could be fixed by re-pushing that branch if you have it, or I think you could re-create it from bcbcab86a4e964a9161f84d37773c1cafcc6f52e according to Packagist: https://packagist.org/packages/hautelook/alice-bundle#1.x-dev

Other links, like for the Scrutinizer badges, have not been updated since those won't work until a new project is created in Scrutinizer.