### PR TITLE
Fix deprecation using Symfony 6.1

### DIFF
--- a/src/Console/Command/Doctrine/DoctrineOrmLoadDataFixturesCommand.php
+++ b/src/Console/Command/Doctrine/DoctrineOrmLoadDataFixturesCommand.php
@@ -21,6 +21,7 @@ use InvalidArgumentException;
 use function sprintf;
 use Symfony\Bundle\FrameworkBundle\Console\Application as FrameworkBundleConsoleApplication;
 use Symfony\Component\Console\Application as ConsoleApplication;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
@@ -32,10 +33,9 @@ use function trigger_error;
 /**
  * Command used to load the fixtures.
  */
+#[AsCommand(name: 'hautelook:fixtures:load', description: 'Load data fixtures to your database.')]
 class DoctrineOrmLoadDataFixturesCommand extends Command
 {
-    protected static $defaultName = 'hautelook:fixtures:load';
-
     private ManagerRegistry $doctrine;
     private AliceBundleLoaderInterface $loader;
 
@@ -53,7 +53,6 @@ class DoctrineOrmLoadDataFixturesCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setAliases([self::$defaultName])
             ->setDescription('Load data fixtures to your database.')
             ->addOption(
                 'bundle',


### PR DESCRIPTION
Overriding "$defaultName" is deprecated since Symfony 6.1

The alias is the same as the name:

https://github.com/theofidry/AliceBundle/blob/016ff236de2b103a88f734cb98761588b7db8b2f/resources/config/command.xml#L10

Ref: https://github.com/symfony/symfony/blob/d09634946b0e9e7035e138b52d6260b2bf7b783c/UPGRADE-6.1.md#console

