### PR TITLE
Ensure that `UnitOfWork` contents are cleaned up after populating database

### DIFF
--- a/src/PhpUnit/BaseDatabaseTrait.php
+++ b/src/PhpUnit/BaseDatabaseTrait.php
@@ -66,14 +66,16 @@ trait BaseDatabaseTrait
     protected static function populateDatabase(): void
     {
         $container = static::$kernel->getContainer();
+        $manager = $container->get('doctrine')->getManager(static::$manager);
         static::$fixtures = $container->get('hautelook_alice.loader')->load(
             new Application(static::$kernel), // OK this is ugly... But there is no other way without redesigning LoaderInterface from the ground.
-            $container->get('doctrine')->getManager(static::$manager),
+            $manager,
             static::$bundles,
             static::$kernel->getEnvironment(),
             static::$append,
             static::$purgeWithTruncate,
             static::$shard
         );
+        $manager->clear();
     }
 }

--- a/tests/PhpUnit/RefreshTestTrait.php
+++ b/tests/PhpUnit/RefreshTestTrait.php
@@ -22,6 +22,11 @@ use Hautelook\AliceBundle\Functional\TestKernel;
  */
 trait RefreshTestTrait
 {
+    public function testUnitOfWorkIsEmptyAtTheStartOfTheTest(): void
+    {
+        self::assertEquals(0, $this->getManager()->getUnitOfWork()->size());
+    }
+
     public function testRefresh(): void
     {
         $manager = $this->getManager();


### PR DESCRIPTION
This pull request fixes #26 by cleaning up the contents of the `UnitOfWork` after populating the database.

The test is added to verify updated behavior.