### PR TITLE
doc: added validation example with a processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A lot of that complexity has been pushed back to nelmio/alice 3.x which has a mu
     1. [Load fixtures in a specific order](doc/advanced-usage.md#load-fixtures-in-a-specific-order)
         1. [Load fixtures in a specific order](doc/advanced-usage.md#ordering-the-files-found)
         1. [Persisting the classes in a specific order](doc/advanced-usage.md#persisting-the-classes-in-a-specific-order)
+   1. [Validation](doc/advanced-usage.md#validation)
 1. [Custom Faker Providers](doc/faker-providers.md)
 1. [Custom Alice Processors](doc/alice-processors.md)
 1. [Resources](#resources)

--- a/doc/advanced-usage.md
+++ b/doc/advanced-usage.md
@@ -239,7 +239,7 @@ Done.
 ## Validation
 
 By default, fixtures are not validated. If you want to trigger the validation you
-can do it with a processor:
+can do it with [a custom processor](alice-processors.md):
 
 ```php
 <?php declare(strict_types=1);

--- a/doc/advanced-usage.md
+++ b/doc/advanced-usage.md
@@ -145,9 +145,9 @@ final class CustomOrderFilesLocator implements FixtureLocatorInterface
     public function locateFiles(array $bundles, string $environment): array
     {
         $files = $this->decoratedFixtureLocator->locateFiles($bundles, $environment);
-        
+
         // TODO: order the files found in whatever order you want
-        
+
         // Warning: the order will only affect how the fixture definitions are merged. Indeed the order in which they
         // are instantiated afterwards by nelmio/alice may change due to handling the fixture dependencies and
         // circular references.
@@ -234,6 +234,48 @@ services:
 ```
 
 Done.
+
+
+## Validation
+
+By default, fixtures are not validated. If you want to trigger the validation you
+can do it with a processor:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures\Processor;
+
+use Fidry\AliceDataFixtures\ProcessorInterface;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class ArticleProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private readonly ValidatorInterface $validator
+    ) {
+    }
+
+    public function preProcess(string $id, object $object): void
+    {
+        /** @var ConstraintViolationList $violations */
+        $violations = $this->validator->validate($object);
+        if ($violations->count() > 0) {
+            $message = sprintf("Error when validating fixture %s, violation(s) detected:\n%s", $id, $violations);
+            throw new \DomainException($message);
+        }
+    }
+
+    public function postProcess(string $id, object $object): void
+    {
+    }
+}
+```
+
+You can find more explanations in this [blog post](https://www.strangebuzz.com/en/blog/validating-your-data-fixtures-with-the-alice-symfony-bundle).
 
 
 Previous chapter: [Basic usage](../README.md#basic-usage)<br />

--- a/doc/advanced-usage.md
+++ b/doc/advanced-usage.md
@@ -242,9 +242,7 @@ By default, fixtures are not validated. If you want to trigger the validation yo
 can do it with a processor:
 
 ```php
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace App\DataFixtures\Processor;
 

--- a/doc/advanced-usage.md
+++ b/doc/advanced-usage.md
@@ -246,6 +246,7 @@ can do it with [a custom processor](alice-processors.md):
 
 namespace App\DataFixtures\Processor;
 
+use DomainException;
 use Fidry\AliceDataFixtures\ProcessorInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -263,7 +264,7 @@ final class ArticleProcessor implements ProcessorInterface
         $violations = $this->validator->validate($object);
         if ($violations->count() > 0) {
             $message = sprintf("Error when validating fixture %s, violation(s) detected:\n%s", $id, $violations);
-            throw new \DomainException($message);
+            throw new DomainException($message);
         }
     }
 


### PR DESCRIPTION
Hello,

* Should we tell how to add the processor tag when not using Symfony autoconfiguration ?

See you. 