### PR TITLE
Fix DB refresh trait for PHP 82

### DIFF
--- a/src/PhpUnit/RefreshDatabaseTrait.php
+++ b/src/PhpUnit/RefreshDatabaseTrait.php
@@ -25,16 +25,14 @@ trait RefreshDatabaseTrait
 {
     use BaseDatabaseTrait;
 
-    protected static bool $dbPopulated = false;
-
     protected static function bootKernel(array $options = []): KernelInterface
     {
         static::ensureKernelTestCase();
         $kernel = parent::bootKernel($options);
 
-        if (!static::$dbPopulated) {
+        if (!defined('HAUTELOOK_DB_POPULATED')) {
             static::populateDatabase();
-            static::$dbPopulated = true;
+            define('HAUTELOOK_DB_POPULATED', true);
         }
 
         $container = static::$kernel->getContainer();


### PR DESCRIPTION
In PHP 8.2 static properties in traits were no longer supported. Due to this issue the database was populated every time at the beginning of a new test class in the refresh trait.

Now we are using a defined var to store if the db is already populated.