### PR TITLE
fix: Ensure the database is not populated several times in PHP 8.2

### DIFF
--- a/src/PhpUnit/RefreshDatabaseState.php
+++ b/src/PhpUnit/RefreshDatabaseState.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Hautelook\AliceBundle\PhpUnit;
+
+final class RefreshDatabaseState
+{
+    private static bool $dbPopulated = false;
+
+    public static function setDbPopulated(bool $populated): void
+    {
+        self::$dbPopulated = $populated;
+    }
+
+    public static function isDbPopulated(): bool
+    {
+        return self::$dbPopulated;
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/src/PhpUnit/RefreshDatabaseTrait.php
+++ b/src/PhpUnit/RefreshDatabaseTrait.php
@@ -25,16 +25,14 @@ trait RefreshDatabaseTrait
 {
     use BaseDatabaseTrait;
 
-    protected static bool $dbPopulated = false;
-
     protected static function bootKernel(array $options = []): KernelInterface
     {
         static::ensureKernelTestCase();
         $kernel = parent::bootKernel($options);
 
-        if (!static::$dbPopulated) {
+        if (!defined('HAUTELOOK_DB_POPULATED')) {
             static::populateDatabase();
-            static::$dbPopulated = true;
+            define('HAUTELOOK_DB_POPULATED', true);
         }
 
         $container = static::$kernel->getContainer();

--- a/src/PhpUnit/RefreshDatabaseTrait.php
+++ b/src/PhpUnit/RefreshDatabaseTrait.php
@@ -30,9 +30,10 @@ trait RefreshDatabaseTrait
         static::ensureKernelTestCase();
         $kernel = parent::bootKernel($options);
 
-        if (!defined('HAUTELOOK_DB_POPULATED')) {
+        if (!RefreshDatabaseState::isDbPopulated()) {
             static::populateDatabase();
-            define('HAUTELOOK_DB_POPULATED', true);
+
+            RefreshDatabaseState::setDbPopulated(true);
         }
 
         $container = static::$kernel->getContainer();


### PR DESCRIPTION
In PHP 8.2 static properties declared in traits behaves as if they were declared in the class using the trait, hence it will no longer be shared between classes using this trait.

Closes #42.

This PR is another take of #42 where the state is kept within an internal constant instead as a constant would mean introducing global state that cannot be mutated which I am not too found of.