### PR TITLE
fix: Ensure fixtures are populated for consecutive tests

### DIFF
--- a/src/PhpUnit/FixtureStore.php
+++ b/src/PhpUnit/FixtureStore.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Hautelook\AliceBundle package.
+ *
+ * (c) Baldur Rensch <brensch@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Hautelook\AliceBundle\PhpUnit;
+
+final class FixtureStore
+{
+    private static ?array $fixtures = null;
+
+    public static function getFixtures(): ?array
+    {
+        return self::$fixtures;
+    }
+
+    public static function setFixtures(array $fixtures): void
+    {
+        self::$fixtures = $fixtures;
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/src/PhpUnit/RefreshDatabaseTrait.php
+++ b/src/PhpUnit/RefreshDatabaseTrait.php
@@ -32,8 +32,11 @@ trait RefreshDatabaseTrait
 
         if (!RefreshDatabaseState::isDbPopulated()) {
             static::populateDatabase();
+            FixtureStore::setFixtures(static::$fixtures);
 
             RefreshDatabaseState::setDbPopulated(true);
+        } else {
+            static::$fixtures = FixtureStore::getFixtures();
         }
 
         $container = static::$kernel->getContainer();


### PR DESCRIPTION
After this PR https://github.com/theofidry/AliceBundle/pull/43, the `self::$fixtures` isn't populated anymore for the tests that are located in other classes. Since the population code is executed only once and stores the fixtures into the first test class static `$fixtures` variable, the other classes will get `self::$fixtures === null`.