### PR TITLE
fix: allow all patch releases of symfony/finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "doctrine/orm": "^3.1",
         "doctrine/persistence": "^3.3.1 || ^4.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
-        "symfony/finder": "7.4 || ^8.0",
+        "symfony/finder": "^7.4 || ^8.0",
         "symfony/framework-bundle": "^7.4 || ^8.0",
         "theofidry/alice-data-fixtures": "^1.10",
         "symfony/doctrine-bridge": "7.4 || ^8.0"


### PR DESCRIPTION
`7.4` is equal to `7.4.0` but does not allow `7.4.1` and above