### PR TITLE
Use FixtureStore to get manager name instead of deprecated static::$m…

### DIFF
--- a/src/PhpUnit/RecreateDatabaseTrait.php
+++ b/src/PhpUnit/RecreateDatabaseTrait.php
@@ -39,7 +39,7 @@ trait RecreateDatabaseTrait
     protected static function buildSchema(): void
     {
         $container = static::$kernel->getContainer();
-        $em = $container->get('doctrine')->getManager(static::$manager);
+        $em = $container->get('doctrine')->getManager(FixtureStore::getManagerName());
         $meta = $em->getMetadataFactory()->getAllMetadata();
 
         if (!empty($meta)) {


### PR DESCRIPTION
When there is a need to use other manager name than default one to build schema we will have an deprecation notice like:

  1x: Since hautelook/alice-bundle 2.12.2: Setting up the database manager via the class static is deprecated. Use FixtureStore::setManagerName() instead.

To be consistent, once you set static::$manager as deprecated, you should get rid of its use.

Here is the deprecation: https://github.com/theofidry/AliceBundle/blob/0442ebc0a671daa5e0f7f683471a8a9b7d6ca483/src/PhpUnit/BaseDatabaseTrait.php#L86

PS I haven't checked the compatibility of this change. I only see a lack of consistency.